### PR TITLE
Debug: Add direct render call for particle visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -568,6 +568,10 @@
             // renderer.setRenderTarget(null); // If trail effect removed
 
             if (controls) controls.update(); // Update controls
+
+            // Add this line for debugging:
+            if (renderer && scene && camera) renderer.render(scene, camera); 
+
             if (composer) composer.render(); // Render post-processing stack
         }
     </script>


### PR DESCRIPTION
To help diagnose why particles are not appearing, this commit adds a direct \`renderer.render(scene, camera);\` call in the \`animate\` function, just before the \`composer.render();\` call.

This will render the main scene directly without post-processing, helping to determine if the issue lies in the basic scene/camera/particle setup or within the EffectComposer chain.