### PR TITLE
Debug: Add error handling and canvas styling for ParticleSlider

### DIFF
--- a/main.js
+++ b/main.js
@@ -8,46 +8,63 @@ var init = function(){
     navigator.userAgent.toLowerCase().indexOf('mobile') >= 0;
   var isSmall = window.innerWidth < 1000;
 
-  var ps = new ParticleSlider({
-    ptlGap: isMobile || isSmall ? 3 : 0,
-    ptlSize: isMobile || isSmall ? 3 : 1,
-    width: 1e9, 
-    height: 1e9 
-  });
+  var ps; // Define ps outside try block to widen its scope if needed
 
-  if (typeof dat === 'undefined') {
-    console.warn('dat.GUI not found. UI controls might not be available or may error. Attempting to create a mock GUI to prevent runtime errors.');
-    window.dat = { 
-        GUI: function() { 
-            this.add = function(obj, prop) { 
-                console.log('Mock dat.GUI: add called for', prop);
-                return { onChange: function(){}, min: function(){ return this; }, max: function(){ return this; }, step: function(){ return this; } }; 
-            }; 
-            this.addColor = function(obj, prop) { 
-                console.log('Mock dat.GUI: addColor called for', prop);
-                return { onChange: function(){} }; 
-            }; 
-        } 
-    };
+  try {
+    console.log("Attempting to initialize ParticleSlider...");
+    ps = new ParticleSlider({
+      ptlGap: isMobile || isSmall ? 3 : 0,
+      ptlSize: isMobile || isSmall ? 3 : 1,
+      width: 1e9, 
+      height: 1e9 
+    });
+    console.log("ParticleSlider initialized successfully:", ps);
+  } catch (e) {
+    console.error("Error initializing ParticleSlider:", e);
+    // Optionally, display a message to the user on the page itself
+    // document.body.innerHTML = '<p>Error initializing ParticleSlider. Is ps-0.9.js loaded?</p>';
+    return; // Stop further execution if ParticleSlider fails
   }
-  var gui = new dat.GUI();
-  gui.add(ps, 'ptlGap').min(0).max(5).step(1).onChange(function(){
-    ps.init(true);
-  });
-  gui.add(ps, 'ptlSize').min(1).max(5).step(1).onChange(function(){
-    ps.init(true);
-  });
-  gui.add(ps, 'restless');
-  gui.addColor(ps, 'color').onChange(function(value){
-    ps.monochrome = true;
-    ps.setColor(value);
-    ps.init(true);
-  });
+
+  try {
+    console.log("Attempting to initialize dat.GUI...");
+    if (typeof dat === 'undefined') {
+      console.warn('dat.GUI not found. UI controls might not be available or may error. Attempting to create a mock GUI to prevent runtime errors.');
+      window.dat = { 
+          GUI: function() { 
+              this.add = function(obj, prop) { 
+                  console.log('Mock dat.GUI: add called for', prop);
+                  return { onChange: function(){}, min: function(){ return this; }, max: function(){ return this; }, step: function(){ return this; } }; 
+              }; 
+              this.addColor = function(obj, prop) { 
+                  console.log('Mock dat.GUI: addColor called for', prop);
+                  return { onChange: function(){} }; 
+              }; 
+          } 
+      };
+    }
+    var gui = new dat.GUI();
+    gui.add(ps, 'ptlGap').min(0).max(5).step(1).onChange(function(){
+      ps.init(true);
+    });
+    gui.add(ps, 'ptlSize').min(1).max(5).step(1).onChange(function(){
+      ps.init(true);
+    });
+    gui.add(ps, 'restless');
+    gui.addColor(ps, 'color').onChange(function(value){
+      ps.monochrome = true;
+      ps.setColor(value);
+      ps.init(true);
+    });
+    console.log("dat.GUI setup complete.");
+  } catch (e) {
+    console.error("Error setting up dat.GUI:", e);
+  }
 
   (window.addEventListener
    ? window.addEventListener('click', function(){ps.init(true)}, false)
    : window.onclick = function(){ps.init(true)});
-}
+};
 
 var initParticleSlider = function(){
   var psScript = document.createElement('script');

--- a/style.css
+++ b/style.css
@@ -44,3 +44,11 @@ html, body {
   height: 32px;
   fill: #1da1f2;
 }
+
+canvas.draw {
+  display: block; /* Ensure it's a block element */
+  width: 100%;    /* Make it take full width of its container */
+  height: 100%;   /* Make it take full height of its container */
+  border: 2px solid red; /* Bright red border for visibility */
+  background-color: rgba(0, 0, 255, 0.1); /* Faint blue background */
+}


### PR DESCRIPTION
To help diagnose issues with the ParticleSlider effect not appearing:
- I added try-catch blocks in main.js around the ParticleSlider instantiation and dat.GUI setup to log potential errors.
- I added CSS styles to style.css for the 'canvas.draw' element to give it a visible red border, a faint blue background, and ensure it attempts to fill its container. This helps verify canvas presence and layout.