### PR TITLE
Refactor: Add explicit ps.init(true) call

### DIFF
--- a/main.js
+++ b/main.js
@@ -26,6 +26,12 @@ var init = function(){
     return; // Stop further execution if ParticleSlider fails
   }
 
+  // Add this new block:
+  if (ps) {
+    console.log('Explicitly calling ps.init(true) post-instantiation.');
+    ps.init(true);
+  }
+
   try {
     console.log("Attempting to initialize dat.GUI...");
     if (typeof dat === 'undefined') {


### PR DESCRIPTION
Adds an explicit call to `ps.init(true)` in `main.js` immediately after the ParticleSlider object (`ps`) is instantiated.

This is to ensure that the particle processing and rendering logic within ParticleSlider is triggered, as it's hypothesized that the constructor alone might not start the effect.