### PR TITLE
Fix: Update CSS to ensure canvas fills viewport

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,10 +1,11 @@
 body {
     margin: 0;
-    overflow: hidden; /* Prevent scrollbars from appearing */
+    overflow: hidden; /* Prevent scrollbars */
+    background-color: #111; /* Dark gray background */
 }
 
-#scene-container {
-    width: 100vw;
-    height: 100vh;
-    display: block;
+canvas#glCanvas {
+    display: block; /* Remove any default spacing */
+    width: 100vw;   /* Full viewport width */
+    height: 100vh;  /* Full viewport height */
 }


### PR DESCRIPTION
- I modified style.css to set body margin to 0 and overflow to hidden.
- I set canvas#glCanvas display to block and width/height to 100vw/100vh.

This addresses the issue where the canvas was appearing as a small box, and should now make it fill the entire browser window.