### PR TITLE
Debug: Force fragment shader to output green

### DIFF
--- a/fragment_shader.glsl
+++ b/fragment_shader.glsl
@@ -1,17 +1,7 @@
-precision mediump float; // Necessary for fragment shaders
-
-// Varying received from the vertex shader
-varying vec2 v_textureCoord;
-
-// Uniform for the image texture
-uniform sampler2D u_imageTexture;
-
+precision mediump float;
+varying vec2 v_textureCoord; // Keep it, even if not used, to match vertex shader
+uniform sampler2D u_imageTexture; // Keep it, even if not used
 void main() {
-    // Sample the texture at the given texture coordinate
-    vec4 textureColor = texture2D(u_imageTexture, v_textureCoord);
-
-    // Output the color
-    gl_FragColor = textureColor;
-    // For testing without a texture yet, you can output a fixed color:
-    // gl_FragColor = vec4(0.0, 1.0, 0.0, 1.0); // Green
+    // Output a constant bright green color for debugging
+    gl_FragColor = vec4(0.0, 1.0, 0.0, 1.0); // Bright Green
 }


### PR DESCRIPTION
To diagnose the black screen issue, I've temporarily modified the fragment_shader.glsl to output a constant bright green color. This will help you determine if the problem lies in the rendering of the point itself or in the texturing process.