### PR TITLE
I made a couple of changes to debug the issue with the sample center …

### DIFF
--- a/fragment_shader.glsl
+++ b/fragment_shader.glsl
@@ -1,7 +1,10 @@
 precision mediump float;
-varying vec2 v_textureCoord; // Keep it, even if not used, to match vertex shader
-uniform sampler2D u_imageTexture; // Keep it, even if not used
+
+varying vec2 v_textureCoord;
+uniform sampler2D u_imageTexture;
+
 void main() {
-    // Output a constant bright green color for debugging
-    gl_FragColor = vec4(0.0, 1.0, 0.0, 1.0); // Bright Green
+    // Sample the texture at the given texture coordinate
+    vec4 textureColor = texture2D(u_imageTexture, v_textureCoord);
+    gl_FragColor = textureColor;
 }

--- a/pixel_animation.js
+++ b/pixel_animation.js
@@ -153,8 +153,8 @@ function initBuffers() {
     gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
     gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(positions), gl.STATIC_DRAW);
 
-    // Texture Coordinate Buffer (Placeholder)
-    const textureCoordinates = [0.0, 0.0]; // Placeholder
+    // Texture Coordinate Buffer - updated to sample center of texture
+    const textureCoordinates = [0.5, 0.5]; // Sample center of the texture
     textureCoordBuffer = gl.createBuffer();
     if (!textureCoordBuffer) {
         console.error("Failed to create the texture coordinate buffer.");


### PR DESCRIPTION
…texture coordinate for a single point.

First, I reverted `fragment_shader.glsl` so it samples from `u_imageTexture`. Then, I modified `initBuffers` in `pixel_animation.js` to set the single test point's texture coordinate to `[0.5, 0.5]`.

I'm doing this to see if the black screen you were seeing was because the previous texture coordinate `[0.0, 0.0]` was sampling a black or transparent part of the image. If this works, you should see a colored point.